### PR TITLE
Multiple changes

### DIFF
--- a/fec.go
+++ b/fec.go
@@ -14,6 +14,7 @@ const (
 	typeData           = 0xf1
 	typeFEC            = 0xf2
 	fecExpire          = 30000 // 30s
+	rxFecLimit         = 2048
 )
 
 type (
@@ -41,16 +42,16 @@ type (
 	}
 )
 
-func newFEC(rxlimit, dataShards, parityShards int) *FEC {
+func NewFEC(dataShards, parityShards int) *FEC {
 	if dataShards <= 0 || parityShards <= 0 {
 		return nil
 	}
-	if rxlimit < dataShards+parityShards {
+	if rxFecLimit < dataShards+parityShards {
 		return nil
 	}
 
 	fec := new(FEC)
-	fec.rxlimit = rxlimit
+	fec.rxlimit = rxFecLimit
 	fec.dataShards = dataShards
 	fec.parityShards = parityShards
 	fec.shardSize = dataShards + parityShards

--- a/fec_test.go
+++ b/fec_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestFECOther(t *testing.T) {
-	if newFEC(128, 0, 1) != nil {
+	if NewFEC(0, 1) != nil {
 		t.Fail()
 	}
-	if newFEC(128, 0, 0) != nil {
+	if NewFEC(0, 0) != nil {
 		t.Fail()
 	}
-	if newFEC(1, 10, 10) != nil {
+	if NewFEC(1024, 1025) != nil {
 		t.Fail()
 	}
 }

--- a/sess_test.go
+++ b/sess_test.go
@@ -23,7 +23,7 @@ func DialTest() (*UDPSession, error) {
 	//block, _ := NewSimpleXORBlockCrypt(pass)
 	//block, _ := NewTEABlockCrypt(pass[:16])
 	//block, _ := NewAESBlockCrypt(pass)
-	return DialWithOptions(port, block, 10, 3)
+	return Dial(port, block, NewFEC(10, 3))
 }
 
 func ListenTest() (*Listener, error) {
@@ -32,7 +32,7 @@ func ListenTest() (*Listener, error) {
 	//block, _ := NewSimpleXORBlockCrypt(pass)
 	//block, _ := NewTEABlockCrypt(pass[:16])
 	//block, _ := NewAESBlockCrypt(pass)
-	return ListenWithOptions(port, block, 10, 3)
+	return ListenWithOptions(port, block, NewFEC(10, 3))
 }
 
 func server() {


### PR DESCRIPTION
1. Use interfaces instead of concrete types
2. Allow creating connections from the provided connection
3. Add deadlines to Listener (only read is used for accepting for now)
4. Allow disabling logging
5. Return a proper timeout error (net.Error)

Another thing which would be nice to add is DialWithTimeout, but as far as I understand the protocol, there are no handshake as such until data is actually sent, hence it wouldn't make any sense?