### PR TITLE
修复不能在IPv4下监听UDP端口的问题

### DIFF
--- a/sess.go
+++ b/sess.go
@@ -36,8 +36,7 @@ const (
 )
 
 const (
-	errBrokenPipe       = "broken pipe"
-	errInvalidOperation = "invalid operation"
+	errBrokenPipe = "broken pipe"
 )
 
 var (
@@ -349,7 +348,7 @@ func (s *UDPSession) SetDSCP(dscp int) error {
 			return ipv4.NewConn(nc).SetTOS(dscp << 2)
 		}
 	}
-	return errors.New(errInvalidOperation)
+	return nil
 }
 
 // SetReadBuffer sets the socket read buffer, no effect if it's accepted from Listener
@@ -361,7 +360,7 @@ func (s *UDPSession) SetReadBuffer(bytes int) error {
 			return nc.SetReadBuffer(bytes)
 		}
 	}
-	return errors.New(errInvalidOperation)
+	return nil
 }
 
 // SetWriteBuffer sets the socket write buffer, no effect if it's accepted from Listener
@@ -373,7 +372,7 @@ func (s *UDPSession) SetWriteBuffer(bytes int) error {
 			return nc.SetWriteBuffer(bytes)
 		}
 	}
-	return errors.New(errInvalidOperation)
+	return nil
 }
 
 // SetKeepAlive changes per-connection NAT keepalive interval; 0 to disable, default to 10s
@@ -769,7 +768,7 @@ func (l *Listener) SetReadBuffer(bytes int) error {
 	if nc, ok := l.conn.(setReadBuffer); ok {
 		return nc.SetReadBuffer(bytes)
 	}
-	return errors.New(errInvalidOperation)
+	return nil
 }
 
 // SetWriteBuffer sets the socket write buffer for the Listener
@@ -777,7 +776,7 @@ func (l *Listener) SetWriteBuffer(bytes int) error {
 	if nc, ok := l.conn.(setWriteBuffer); ok {
 		return nc.SetWriteBuffer(bytes)
 	}
-	return errors.New(errInvalidOperation)
+	return nil
 }
 
 // SetDSCP sets the 6bit DSCP field of IP header
@@ -785,7 +784,7 @@ func (l *Listener) SetDSCP(dscp int) error {
 	if nc, ok := l.conn.(net.Conn); ok {
 		return ipv4.NewConn(nc).SetTOS(dscp << 2)
 	}
-	return errors.New(errInvalidOperation)
+	return nil
 }
 
 // Accept implements the Accept method in the Listener interface; it waits for the next call and returns a generic Conn.
@@ -841,18 +840,49 @@ func (l *Listener) Addr() net.Addr {
 }
 
 // Listen listens for incoming KCP packets addressed to the local address laddr on the network "udp",
-func Listen(laddr string) (net.Listener, error) {
-	return ListenWithOptions(laddr, nil, 0, 0)
+func Listen(laddr string, udp4 string, ipv4Only bool) (net.Listener, error) {
+	return ListenWithOptions(laddr, nil, 0, 0, ipv4Only)
 }
 
 // ListenWithOptions listens for incoming KCP packets addressed to the local address laddr on the network "udp" with packet encryption,
 // dataShards, parityShards defines Reed-Solomon Erasure Coding parameters
-func ListenWithOptions(laddr string, block BlockCrypt, dataShards, parityShards int) (*Listener, error) {
-	udpaddr, err := net.ResolveUDPAddr("udp", laddr)
+func ListenWithOptions(laddr string, block BlockCrypt, dataShards, parityShards int, ipv4Only bool) (*Listener, error) {
+	if true == ipv4Only {
+		udpaddr, err := net.ResolveUDPAddr("udp4", laddr)
+
+		if err != nil {
+			return nil, errors.Wrap(err, "net.ResolveUDPAddr")
+		}
+
+		conn, err := net.ListenUDP("udp4", udpaddr)
+		if err != nil {
+			return nil, errors.Wrap(err, "net.ListenUDP")
+		}
+
+		return ServeConn(block, dataShards, parityShards, conn)
+	} else {
+		udpaddr, err := net.ResolveUDPAddr("udp", laddr)
+		if err != nil {
+			return nil, errors.Wrap(err, "net.ResolveUDPAddr")
+		}
+		conn, err := net.ListenUDP("udp", udpaddr)
+		if err != nil {
+			return nil, errors.Wrap(err, "net.ListenUDP")
+		}
+
+		return ServeConn(block, dataShards, parityShards, conn)
+	}
+}
+
+// ListenWithOptions listens for incoming KCP packets addressed to the local address laddr on the network "udp" with packet encryption,
+// dataShards, parityShards defines Reed-Solomon Erasure Coding parameters
+func ListenWithOptionsUDP4(laddr string, block BlockCrypt, dataShards, parityShards int) (*Listener, error) {
+	udpaddr, err := net.ResolveUDPAddr("udp4", laddr)
 	if err != nil {
 		return nil, errors.Wrap(err, "net.ResolveUDPAddr")
 	}
-	conn, err := net.ListenUDP("udp", udpaddr)
+
+	conn, err := net.ListenUDP("udp4", udpaddr)
 	if err != nil {
 		return nil, errors.Wrap(err, "net.ListenUDP")
 	}


### PR DESCRIPTION
https://github.com/xtaci/kcptun/issues/75   以前的issues前几天遇到了，fork一份来修改，net.ResolveUDPAddr和net.ListenUDP指定udp4模式就可以了。加了一个ipv4Only的开关来控制，golang初学者，希望作者能做出更好的代码调整。