### PR TITLE
修复cfb模式 初始vector重复使用的问题

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -68,7 +68,9 @@ func NewTwofishBlockCrypt(key []byte) (BlockCrypt, error) {
 	}
 	c.block = block
 	c.encbuf = make([]byte, twofish.BlockSize)
+	c.block.Encrypt(c.encbuf[:twofish.BlockSize], initialVector[:twofish.BlockSize])
 	c.decbuf = make([]byte, 2*twofish.BlockSize)
+	c.block.Encrypt(c.decbuf[:twofish.BlockSize], initialVector[:twofish.BlockSize])
 	return c, nil
 }
 
@@ -90,7 +92,10 @@ func NewTripleDESBlockCrypt(key []byte) (BlockCrypt, error) {
 	}
 	c.block = block
 	c.encbuf = make([]byte, des.BlockSize)
+	c.block.Encrypt(c.encbuf[:des.BlockSize], initialVector[:des.BlockSize])
 	c.decbuf = make([]byte, 2*des.BlockSize)
+	c.block.Encrypt(c.decbuf[:des.BlockSize], initialVector[:des.BlockSize])
+
 	return c, nil
 }
 
@@ -112,7 +117,10 @@ func NewCast5BlockCrypt(key []byte) (BlockCrypt, error) {
 	}
 	c.block = block
 	c.encbuf = make([]byte, cast5.BlockSize)
+	c.block.Encrypt(c.encbuf[:cast5.BlockSize], initialVector[:cast5.BlockSize])
 	c.decbuf = make([]byte, 2*cast5.BlockSize)
+	c.block.Encrypt(c.decbuf[:cast5.BlockSize], initialVector[:cast5.BlockSize])
+
 	return c, nil
 }
 
@@ -134,7 +142,10 @@ func NewBlowfishBlockCrypt(key []byte) (BlockCrypt, error) {
 	}
 	c.block = block
 	c.encbuf = make([]byte, blowfish.BlockSize)
+	c.block.Encrypt(c.encbuf[:blowfish.BlockSize], initialVector[:blowfish.BlockSize])
 	c.decbuf = make([]byte, 2*blowfish.BlockSize)
+	c.block.Encrypt(c.decbuf[:blowfish.BlockSize], initialVector[:blowfish.BlockSize])
+
 	return c, nil
 }
 
@@ -156,7 +167,10 @@ func NewAESBlockCrypt(key []byte) (BlockCrypt, error) {
 	}
 	c.block = block
 	c.encbuf = make([]byte, aes.BlockSize)
+	c.block.Encrypt(c.encbuf[:aes.BlockSize], initialVector[:aes.BlockSize])
 	c.decbuf = make([]byte, 2*aes.BlockSize)
+	c.block.Encrypt(c.decbuf[:aes.BlockSize], initialVector[:aes.BlockSize])
+
 	return c, nil
 }
 
@@ -178,7 +192,10 @@ func NewTEABlockCrypt(key []byte) (BlockCrypt, error) {
 	}
 	c.block = block
 	c.encbuf = make([]byte, tea.BlockSize)
+	c.block.Encrypt(c.encbuf[:tea.BlockSize], initialVector[:tea.BlockSize])
 	c.decbuf = make([]byte, 2*tea.BlockSize)
+	c.block.Encrypt(c.decbuf[:tea.BlockSize], initialVector[:tea.BlockSize])
+
 	return c, nil
 }
 
@@ -200,7 +217,10 @@ func NewXTEABlockCrypt(key []byte) (BlockCrypt, error) {
 	}
 	c.block = block
 	c.encbuf = make([]byte, xtea.BlockSize)
+	c.block.Encrypt(c.encbuf[:xtea.BlockSize], initialVector[:xtea.BlockSize])
 	c.decbuf = make([]byte, 2*xtea.BlockSize)
+	c.block.Encrypt(c.decbuf[:xtea.BlockSize], initialVector[:xtea.BlockSize])
+
 	return c, nil
 }
 
@@ -235,7 +255,7 @@ func (c *noneBlockCrypt) Decrypt(dst, src []byte) { copy(dst, src) }
 func encrypt(block cipher.Block, dst, src, buf []byte) {
 	blocksize := block.BlockSize()
 	tbl := buf[:blocksize]
-	block.Encrypt(tbl, initialVector)
+	block.Encrypt(tbl, tbl)
 	n := len(src) / blocksize
 	base := 0
 	for i := 0; i < n; i++ {
@@ -250,7 +270,7 @@ func decrypt(block cipher.Block, dst, src, buf []byte) {
 	blocksize := block.BlockSize()
 	tbl := buf[:blocksize]
 	next := buf[blocksize:]
-	block.Encrypt(tbl, initialVector)
+	block.Encrypt(tbl, tbl)
 	n := len(src) / blocksize
 	base := 0
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
不应该重复使用初始vector，否则就和ECB模式一样了，无法抵御重放攻击，而且容易被人找到某种“模式”。
参考：
[分组密码工作模式](https://zh.wikipedia.org/zh-cn/%E5%88%86%E7%BB%84%E5%AF%86%E7%A0%81%E5%B7%A5%E4%BD%9C%E6%A8%A1%E5%BC%8F)
[高级加密标准AES的工作模式（ECB、CBC、CFB、OFB](http://blog.csdn.net/charleslei/article/details/48710293)