### PR TITLE
Short linter errors fixes

### DIFF
--- a/kcp.go
+++ b/kcp.go
@@ -486,7 +486,7 @@ func (kcp *KCP) parse_data(newseg segment) {
 // Input when you received a low level packet (eg. UDP packet), call it
 // regular indicates a regular packet has received(not from FEC)
 func (kcp *KCP) Input(data []byte, regular, ackNoDelay bool) int {
-	una := kcp.snd_una
+	snd_una := kcp.snd_una
 	if len(data) < IKCP_OVERHEAD {
 		return -1
 	}
@@ -587,7 +587,7 @@ func (kcp *KCP) Input(data []byte, regular, ackNoDelay bool) int {
 		}
 	}
 
-	if _itimediff(kcp.snd_una, una) > 0 {
+	if _itimediff(kcp.snd_una, snd_una) > 0 {
 		if kcp.cwnd < kcp.rmt_wnd {
 			mss := kcp.mss
 			if kcp.cwnd < kcp.ssthresh {

--- a/rand.go
+++ b/rand.go
@@ -21,5 +21,4 @@ func (n *nonceMD5) Fill(nonce []byte) {
 	}
 	n.data = md5.Sum(n.data[:])
 	copy(nonce, n.data[:])
-	return
 }

--- a/sess.go
+++ b/sess.go
@@ -755,10 +755,10 @@ func (l *Listener) monitor() {
 
 					if !ok { // new session
 						if !blacklist.has(from.String(), conv) && len(l.chAccepts) < cap(l.chAccepts) && len(l.sessions) < 4096 { // do not let new session overwhelm accept queue and connection count
-							s := newUDPSession(conv, l.dataShards, l.parityShards, l, l.conn, from, l.block)
-							s.kcpInput(data)
-							l.sessions[key] = s
-							l.chAccepts <- s
+							ses := newUDPSession(conv, l.dataShards, l.parityShards, l, l.conn, from, l.block)
+							ses.kcpInput(data)
+							l.sessions[key] = ses
+							l.chAccepts <- ses
 						}
 					} else {
 						s.kcpInput(data)


### PR DESCRIPTION
Fixed 2 shadow variables and 1 redundant `return`.