### PR TITLE
use heap.Fix() instead of Pop() and Push()

### DIFF
--- a/updater.go
+++ b/updater.go
@@ -87,12 +87,11 @@ func (h *updateHeap) updateTask() {
 		hlen := h.Len()
 		now := time.Now()
 		for i := 0; i < hlen; i++ {
-			entry := heap.Pop(h).(entry)
+			entry := &h.entries[0]
 			if now.After(entry.ts) {
 				entry.ts = now.Add(entry.s.update())
-				heap.Push(h, entry)
+				heap.Fix(h, 0)
 			} else {
-				heap.Push(h, entry)
 				break
 			}
 		}


### PR DESCRIPTION
From container/heap's doc:
Changing the value of the element at index i and then calling Fix is equivalent to, but less expensive than, calling Remove(h, i) followed by a Push of the new value.