### PR TITLE
Raise Max Sessions to 32k

### DIFF
--- a/sess.go
+++ b/sess.go
@@ -42,6 +42,9 @@ const (
 
 	// prerouting(to session) queue
 	qlen = 128
+
+	// maximum absolute number of sessions
+	maxSessions = 4096
 )
 
 const (
@@ -758,7 +761,7 @@ func (l *Listener) monitor() {
 					}
 
 					if !ok { // new session
-						if !blacklist.has(from.String(), conv) && len(l.chAccepts) < cap(l.chAccepts) && len(l.sessions) < 4096 { // do not let new session overwhelm accept queue and connection count
+						if !blacklist.has(from.String(), conv) && len(l.chAccepts) < cap(l.chAccepts) && len(l.sessions) < maxSessions { // do not let new session overwhelm accept queue and connection count
 							ses := newUDPSession(conv, l.dataShards, l.parityShards, l, l.conn, from, l.block)
 							ses.kcpInput(data)
 							l.sessions[key] = ses

--- a/sess.go
+++ b/sess.go
@@ -44,7 +44,7 @@ const (
 	qlen = 128
 
 	// maximum absolute number of sessions
-	maxSessions = 4096
+	maxSessions = 32768
 )
 
 const (


### PR DESCRIPTION
Currently the maximum number of sessions is hard coded to 4096. This PR makes this limit a const variable, and raises it to 32k. We are using it in production without issues so far.