### PR TITLE
Let iclock() return currentMs()

### DIFF
--- a/kcp_test.go
+++ b/kcp_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func iclock() int32 {
-	return int32((time.Now().UnixNano() / 1000000) & 0xffffffff)
+	return int32(currentMs())
 }
 
 type DelayPacket struct {


### PR DESCRIPTION
Let iclock() return currentMs() to make it monotonic.