### PR TITLE
multiple updater for massive connections

### DIFF
--- a/sess.go
+++ b/sess.go
@@ -50,9 +50,8 @@ var (
 var (
 	// a system-wide packet buffer shared among sending, receiving and FEC
 	// to mitigate high-frequency memory allocation for packets
-	xmitBuf       sync.Pool
-	updaterLocker sync.Mutex
-	updater       *updateHeap
+	xmitBuf sync.Pool
+	updater = newUpdater()
 )
 
 func init() {
@@ -177,11 +176,6 @@ func newUDPSession(conv uint32, dataShards, parityShards int, l *Listener, conn 
 	// which call sess.update() periodically.
 
 	if sess.l == nil { // it's a client connection
-		updaterLocker.Lock()
-		if updater == nil {
-			updater = newUpdater()
-		}
-		updaterLocker.Unlock()
 		updater.addSession(sess)
 		go sess.readLoop()
 		atomic.AddUint64(&DefaultSnmp.ActiveOpens, 1)

--- a/sess_test.go
+++ b/sess_test.go
@@ -555,7 +555,7 @@ func TestListenerClose(t *testing.T) {
 
 	l.Close()
 	fakeaddr, _ := net.ResolveUDPAddr("udp6", "127.0.0.1:1111")
-	if l.closeSession(fakeaddr) {
+	if l.closeSession(fakeaddr, 0) {
 		t.Fail()
 	}
 }

--- a/updater.go
+++ b/updater.go
@@ -6,11 +6,11 @@ import (
 	"time"
 )
 
-var updater updateHeap
-
-func init() {
+func newUpdater() *updateHeap {
+	updater := new(updateHeap)
 	updater.init()
 	go updater.updateTask()
+	return updater
 }
 
 // entry contains a session update info


### PR DESCRIPTION
1. 处理大规模连接的时候，单个updater性能不够，这里扩展成每个listener分配一个updater，方便通过SO_REUSEPORT特性进行扩展。
2. 大规模连接的时候，如果前面的连接没有释放，其他连接以相同的ip端口过来的时候就会把数据发到老的连接里面去。所以在创建连接的时候增加了conv判断，保证一个ip端口只有最新的conv有效。
3. 将锁改为读写锁，方便扩展接收数据协程