### PR TITLE
Prevent write from overflowing congestion window

### DIFF
--- a/sess.go
+++ b/sess.go
@@ -277,9 +277,10 @@ func (s *UDPSession) WriteBuffers(v [][]byte) (n int, err error) {
 
 		s.mu.Lock()
 
-		// make sure write do not overflow the max sliding window on both side
+		// make sure write do not overflow the max sliding window on both side or our congestion window
 		waitsnd := s.kcp.WaitSnd()
-		if waitsnd < int(s.kcp.snd_wnd) && waitsnd < int(s.kcp.rmt_wnd) {
+		if waitsnd < int(s.kcp.snd_wnd) && waitsnd < int(s.kcp.rmt_wnd) &&
+		(s.kcp.nocwnd == 1 || waitsnd < int(s.kcp.cwnd)) {
 			for _, b := range v {
 				n += len(b)
 				for {


### PR DESCRIPTION
This prevents massive "bufferbloat" when the send window is large but the congestion window is not. It makes KCP with congestion control a *lot* more usable.