### PR TITLE
提升低pps情况下FEC的效果

### DIFF
--- a/fec.go
+++ b/fec.go
@@ -318,7 +318,7 @@ func (enc *fecEncoder) encode(b []byte) (ps [][]byte) {
 	enc.shardCache[enc.shardCount] = enc.shardCache[enc.shardCount][:sz]
 	copy(enc.shardCache[enc.shardCount][enc.payloadOffset:], b[enc.payloadOffset:])
 	enc.shardCount++
-	if enc.shardCount == 1 {
+	if enc.shardCount == 1 && enc.forceEncodeMinInterval > 0 {
 		enc.forceEncodeAvailableAt = time.Now().UnixNano() + enc.forceEncodeMinInterval
 	}
 

--- a/fec.go
+++ b/fec.go
@@ -406,8 +406,8 @@ func (enc *fecEncoder) makePadding(seq uint32, seqStart uint32, seqEnd uint32) (
 
 }
 
-func (enc *fecEncoder) fillSeqRange(buffer[] byte, start uint32, end uint32) {
-	payload := buffer[enc.payloadOffset + 2:]
+func (enc *fecEncoder) fillSeqRange(buffer []byte, start uint32, end uint32) {
+	payload := buffer[enc.payloadOffset+2:]
 	binary.LittleEndian.PutUint32(payload, start)
 	binary.LittleEndian.PutUint32(payload[4:], end)
 }

--- a/fec.go
+++ b/fec.go
@@ -117,11 +117,11 @@ func (dec *fecDecoder) decode(in fecPacket) (recovered [][]byte) {
 				pkt = temporaryPkt
 			}
 		}
-		if pkt == nil {
-			return nil
-		}
 	} else {
 		insertIdx, pkt = dec.insertFecPacket(in)
+	}
+	if pkt == nil {
+		return nil
 	}
 
 	// shard range for current packet

--- a/fec_test.go
+++ b/fec_test.go
@@ -1,6 +1,7 @@
 package kcp
 
 import (
+	"bytes"
 	"encoding/binary"
 	"math/rand"
 	"testing"
@@ -39,5 +40,80 @@ func BenchmarkFECEncode(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		data := make([]byte, payLoad)
 		encoder.encode(data)
+	}
+}
+
+func TestForceEncodeAndDecode(t *testing.T) {
+	const dataSize = 10
+	const paritySize = 3
+	const payLoad = 1500
+
+	encoder := newFECEncoder(dataSize, paritySize, 0)
+
+	payload2Make := dataSize / 2
+
+	payloadBuffer := make([][]byte, payload2Make)
+
+	// only half of datasize in shard cache
+	for i := 0; i < payload2Make; i++ {
+		data := make([]byte, payLoad)
+		payloadBuffer[i] = data
+		binary.LittleEndian.PutUint32(data, uint32(i))
+		encoder.encode(data)
+	}
+
+	padding2Make := dataSize - payload2Make
+	pb, ps := encoder.forceEncode()
+	if len(pb) != padding2Make {
+		t.Fatalf("generated padding %d not equal required %d", len(pb), padding2Make)
+	}
+	if len(ps) != paritySize {
+		t.Fatalf("generated parityshard %d less not equal to requird %d", len(ps), paritySize)
+	}
+	for i := range pb {
+		if fecPacket(pb[i]).flag() != typePadding {
+			t.Fatalf("non-padding type appears in paddings")
+		}
+	}
+	for i := range ps {
+		if fecPacket(ps[i]).flag() != typeParity {
+			t.Fatalf("non-partishard type appears in partishards")
+		}
+	}
+
+	decoder := newFECDecoder(1024, dataSize, paritySize)
+LostPayloadIterator:
+	for lostPayload := 1; lostPayload <= payload2Make; lostPayload++ {
+		if (payload2Make-lostPayload)+padding2Make+paritySize < dataSize {
+			break
+		}
+		payload2Recover := payloadBuffer[:lostPayload]
+		payloadBufferSlice := payloadBuffer[lostPayload:]
+		for i := range payloadBufferSlice {
+			decoder.decode(payloadBufferSlice[i])
+		}
+		// recover all padding by single padding
+		if len(pb) > 0 {
+			decoder.decode(pb[0])
+		}
+		for i := range ps {
+			recovered := decoder.decode(ps[i])
+			if recovered == nil {
+				continue
+			} else {
+			RecoveredCompare:
+				for r := range recovered {
+					for p := range payload2Recover {
+						if bytes.Compare(payload2Recover[r], payload2Recover[p]) == 0 {
+							payload2Recover[p] = nil
+							continue RecoveredCompare
+						}
+					}
+					t.Fatalf("recovered payload not equal to origin payload")
+				}
+				continue LostPayloadIterator
+			}
+		}
+		t.Fatalf("can not recover payload")
 	}
 }

--- a/sess.go
+++ b/sess.go
@@ -463,6 +463,12 @@ func (s *UDPSession) SetRapidFec(enable bool) {
 	s.rapidFec = enable
 }
 
+func (s *UDPSession) SetRapidFecMinInterval(duration time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.fecEncoder.setForceEncodeMinInterval(duration)
+}
+
 // (deprecated)
 //
 // SetDUP duplicates udp packets for kcp output.

--- a/sess.go
+++ b/sess.go
@@ -714,7 +714,7 @@ func (s *UDPSession) kcpInput(data []byte) {
 	if s.fecDecoder != nil {
 		if len(data) > fecHeaderSize { // must be larger than fec header size
 			f := fecPacket(data)
-			if f.flag() == typeData || f.flag() == typeParity { // header check
+			if f.flag() == typeData || f.flag() == typeParity || f.flag() == typePadding { // header check
 				if f.flag() == typeParity {
 					fecParityShards++
 				}


### PR DESCRIPTION
当前kcp-go的fec策略是仅当shard cache凑齐--datashard个shard时，才生成parityshard发送出去，pps较低的情况下，fec很可能起不了太大作用，甚至回退到补发，这样出现丢包时丢包那部分数据包延迟会大幅度上涨。

这里为了避免这种情况，引入了fec的padding，如果shard cache中的shard不足--datashard个时，使用fec padding补齐；通过UDPSession.SetRapidFec(true)调用可以启用该功能。

fec padding是有固定规则的，所以对方收到一个fec padding，就可以推测出其余的fec padding。

这里修改的代码，利用UDPSession.updater() 的循环被调用，调用fecEncoder.forceEncode()，当shard cache中的shard不为0时，生成fec padding填充shard cache，生成parityshard发送给对方。

例如--datashard 20 --parityshard 10，如果UDPSession.updater()被调用时，shard cache中目前有3个shard，则生成17个fec padding，然后再生成10个parityshard，发送给对方。如果前面发出去的那3个数据包全丢了，对方收到任何一个fec padding+至少3个parityshard，即可恢复那3个数据包。

生成fec padding有一个最短的生成周期，通过fecEncoder.setForceEncodeMinInterval()方法可以设置，因为高pps的情况下，一批数据包刚刚发出去，很可能立刻又调度到UDPSession.updater()，这时是没有生成fec padding的必要，因为高pps情况下的下一次调用UDPSession.output()，一般都可以生成parityshard。每次调用fecEncoder.encode()时，如果shard cache中shard的数目为1，则等到当前时间+interval后才能调用fecEncoder.forceEncode()生成padding。

关于带宽的利用率，pps越低，带宽利用率肯定是越低的，但是pps低，多发一点出去也不会占用多少带宽；pps高的情况下，通过fecEncoder.setForceEncodeMinInterval()设置合理的周期即可（可以和kcp interval一致：time.Duration(KCPInterval) * time.Millisecond），我这边测试，fast3模式在ds:ps 20:12的情况下，比未启用rapid fec多占用至多3 Mbps。

最后附上效果测试图，是一个使用kcp封装的vpn，左上是未启用rapid fec，右上是启用了rapid fec，下方是裸线路：
![mtr.png](https://i.loli.net/2019/11/19/reR8t1vy9sm4gqC.png)