### PR TITLE
close old session if conv conflict and sn = 0 && only create new kcp …

### DIFF
--- a/sess.go
+++ b/sess.go
@@ -820,7 +820,7 @@ func (l *Listener) packetInput(data []byte, addr net.Addr) {
 			}
 		}
 
-		if s == nil && convValid && sn == 0 { // new address:port or new session
+		if s == nil && convValid { // new address:port or new session
 			if len(l.chAccepts) < cap(l.chAccepts) { // do not let the new sessions overwhelm accept queue
 				s := newUDPSession(conv, l.dataShards, l.parityShards, l, l.conn, addr, l.block)
 				s.kcpInput(data)


### PR DESCRIPTION
两个修改：
1. 如果同一个ip:port收到冲突的conv，且sn=0，说明该端口在kcp超时时间内被客户端重用了。此时关闭旧的session，创建新session。
2. 仅当收到sn=0的packet时，才创建新连接。避免服务端主动关闭连接后，客户端重发之前的包导致连接重开。这个修改可能引起当创建新连接时，客户端同时发送多个包，在sn=0之前到达的包被丢弃，需要重传，个人认为这个是可以接收的。

udp端口在短时间内很容易重用，见该测试：https://gist.github.com/wudeng/f227bdd4becc786d8e3a9d213b0475c3


跟issue #150 有相关性。