### PR TITLE
fix: mtu limit

### DIFF
--- a/sess.go
+++ b/sess.go
@@ -32,8 +32,8 @@ const (
 	// overall crypto header size
 	cryptHeaderSize = nonceSize + crcSize
 
-	// maximum packet size
-	mtuLimit = 1500
+	// maximum packet size. ignore udp header to avoid package divided by IP layer
+	mtuLimit = 1500 - 8
 
 	// accept backlog
 	acceptBacklog = 128


### PR DESCRIPTION
代码里mtu是1500的情况下，加上udp的包头，会超过网络层的mtu，导致ip层的分包。ip层分包传输是不可靠的，会降低kcp的可靠性