### PR TITLE
添加了方法Listener.AddConn，可自行添加远端，复用监听链接（net.Conn）

### DIFF
--- a/sess.go
+++ b/sess.go
@@ -777,6 +777,24 @@ type (
 	}
 )
 
+func (l *Listener) AddConn(raddr string) (*UDPSession, error) {
+	raddr_, err := net.ResolveUDPAddr("udp", raddr)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	l.sessionLock.Lock()
+	defer l.sessionLock.Unlock()
+	if _, have := l.sessions[raddr_.String()]; have {
+		return nil, errors.New("connect existed")
+	}
+	var convid uint32
+	binary.Read(rand.Reader, binary.LittleEndian, &convid)
+	s := newUDPSession(convid, l.dataShards, l.parityShards, l, l.conn, false, raddr_, l.block)
+	l.sessions[raddr_.String()] = s
+	l.chAccepts <- s
+	return s, nil
+}
+
 // packet input stage
 func (l *Listener) packetInput(data []byte, addr net.Addr) {
 	decrypted := false


### PR DESCRIPTION
listener, _ := kcp.ListenWithOptions(":8081", nil, 10, 3)
defer listener.Close()
session, _ := listener.AddConn("127.0.0.1:8080")
go func() {
	for {
		time.Sleep(time.Second)
		session.Write([]byte("123,123,123"))
	}
}()