### PR TITLE
fix: memory leak

### DIFF
--- a/sess.go
+++ b/sess.go
@@ -1035,7 +1035,10 @@ func (l *Listener) Accept() (net.Conn, error) {
 func (l *Listener) AcceptKCP() (*UDPSession, error) {
 	var timeout <-chan time.Time
 	if tdeadline, ok := l.rd.Load().(time.Time); ok && !tdeadline.IsZero() {
-		timeout = time.After(time.Until(tdeadline))
+		timer := time.NewTimer(time.Until(tdeadline))
+		defer timer.Stop()
+
+		timeout = timer.C
 	}
 
 	select {

--- a/timedsched.go
+++ b/timedsched.go
@@ -83,8 +83,10 @@ func NewTimedSched(parallel int) *TimedSched {
 
 // sched is a goroutine to schedule and execute timed tasks.
 func (ts *TimedSched) sched() {
-	var tasks timedFuncHeap
 	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	var tasks timedFuncHeap
 	drained := false
 	for {
 		select {


### PR DESCRIPTION
```
// Before Go 1.23, this documentation warned that the underlying
// [Timer] would not be recovered by the garbage collector until the
// timer fired, and that if efficiency was a concern, code should use
// NewTimer instead and call [Timer.Stop] if the timer is no longer needed.
// As of Go 1.23, the garbage collector can recover unreferenced,
// unstopped timers. There is no reason to prefer NewTimer when After will do.
```