### PR TITLE
fix: reading low-level net.PacketConn when UDPSession is closed

### DIFF
--- a/readloop.go
+++ b/readloop.go
@@ -34,6 +34,9 @@ func (s *UDPSession) defaultReadLoop() {
 	var src string
 	for {
 		if n, addr, err := s.conn.ReadFrom(buf); err == nil {
+			if s.isClosed() {
+				return
+			}
 			// make sure the packet is from the same source
 			if src == "" { // set source address
 				src = addr.String()

--- a/readloop_linux.go
+++ b/readloop_linux.go
@@ -52,6 +52,9 @@ func (s *UDPSession) readLoop() {
 
 	for {
 		if count, err := s.xconn.ReadBatch(msgs, 0); err == nil {
+			if s.isClosed() {
+				return
+			}
 			for i := 0; i < count; i++ {
 				msg := &msgs[i]
 				// make sure the packet is from the same source

--- a/sess.go
+++ b/sess.go
@@ -402,6 +402,15 @@ RESET_TIMER:
 	}
 }
 
+func (s *UDPSession) isClosed() bool {
+	select {
+	case <-s.die:
+		return true
+	default:
+		return false
+	}
+}
+
 // Close closes the connection.
 func (s *UDPSession) Close() error {
 	var once bool


### PR DESCRIPTION
直接使用kcp.NewConn3构造函数，传递一个已经存在的net.UDPConn的前提下， 即使kcp.UDPSession已经调用了Close.但loop函数不会退出，导致后续无法继续在原来的net.UDPConn上继续创建新的kcp.NewConn3 (因为数据会被前面那个已经Close的kcp.UDPSession给吃掉，特别是linux平台下)


```
	c1, err := kcp.NewConn3(0, uc.LocalAddr(), nil, 0, 0, us)
	require.Nil(t, err)
	c2, err := kcp.NewConn3(0, us.LocalAddr(), nil, 0, 0, uc)
	require.Nil(t, err)
	check(c1, c2)
	c1.Close()
	c2.Close()
	//这里已经关闭了c1,c2，但是c1,c2的loop函数并不会退出，除非us,uc的ReadMsg返回错误。

        //导致重新复用us,uc会无法收到数据
	c1, err = kcp.NewConn3(4321, uc.LocalAddr(), nil, 0, 0, us)
	require.Nil(t, err)
	c2, err = kcp.NewConn3(4321, us.LocalAddr(), nil, 0, 0, uc)
	require.Nil(t, err)
	check(c1, c2)
	log.Println("----------22222222222222222222")
```