### PR TITLE
Use net.Error-compatible timeout error

### DIFF
--- a/sess.go
+++ b/sess.go
@@ -82,9 +82,16 @@ const (
 
 var (
 	errInvalidOperation = errors.New("invalid operation")
-	errTimeout          = errors.New("timeout")
+	errTimeout          = timeoutError{}
 	errNotOwner         = errors.New("not the owner of this connection")
 )
+
+// timeoutError implements net.Error
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
 
 var (
 	// a system-wide packet buffer shared among sending, receiving and FEC


### PR DESCRIPTION
### What this PR does

Replaces the plain `errors.New("timeout")` with a custom error type `timeoutError` that implements the `net.Error` interface.

### Why

This allows users to idiomatically check for timeouts using:

```go
    if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
        // handle timeout
    }
```

Previously, the only way to detect a timeout was to compare `err.Error() == "timeout"`, which is fragile.

### Notes
- The error message string remains `"timeout"` for backward compatibility.

Let me know if you'd prefer a different naming or approach