### PR TITLE
avoid segment copy while maintaining rcv_buf array.

### DIFF
--- a/kcp.go
+++ b/kcp.go
@@ -169,7 +169,7 @@ type KCP struct {
 
 	snd_queue *RingBuffer[segment]
 	rcv_queue *RingBuffer[segment]
-	snd_buf   []segment
+	snd_buf   *RingBuffer[segment]
 	rcv_buf   []segment
 
 	acklist []ackItem
@@ -204,6 +204,7 @@ func NewKCP(conv uint32, output output_callback) *KCP {
 	kcp.ssthresh = IKCP_THRESH_INIT
 	kcp.dead_link = IKCP_DEADLINK
 	kcp.output = output
+	kcp.snd_buf = NewRingBuffer[segment](IKCP_WND_SND * 2)
 	kcp.rcv_queue = NewRingBuffer[segment](IKCP_WND_RCV * 2)
 	kcp.snd_queue = NewRingBuffer[segment](IKCP_WND_SND * 2)
 	return kcp
@@ -407,8 +408,7 @@ func (kcp *KCP) update_ack(rtt int32) {
 }
 
 func (kcp *KCP) shrink_buf() {
-	if len(kcp.snd_buf) > 0 {
-		seg := &kcp.snd_buf[0]
+	if seg, ok := kcp.snd_buf.Peek(); ok {
 		kcp.snd_una = seg.sn
 	} else {
 		kcp.snd_una = kcp.snd_nxt
@@ -420,8 +420,7 @@ func (kcp *KCP) parse_ack(sn uint32) {
 		return
 	}
 
-	for k := range kcp.snd_buf {
-		seg := &kcp.snd_buf[k]
+	for seg := range kcp.snd_buf.ForEach {
 		if sn == seg.sn {
 			// mark and free space, but leave the segment here,
 			// and wait until `una` to delete this, then we don't
@@ -442,8 +441,7 @@ func (kcp *KCP) parse_fastack(sn, ts uint32) {
 		return
 	}
 
-	for k := range kcp.snd_buf {
-		seg := &kcp.snd_buf[k]
+	for seg := range kcp.snd_buf.ForEach {
 		if _itimediff(sn, seg.sn) < 0 {
 			break
 		} else if sn != seg.sn && _itimediff(seg.ts, ts) <= 0 {
@@ -454,8 +452,7 @@ func (kcp *KCP) parse_fastack(sn, ts uint32) {
 
 func (kcp *KCP) parse_una(una uint32) int {
 	count := 0
-	for k := range kcp.snd_buf {
-		seg := &kcp.snd_buf[k]
+	for seg := range kcp.snd_buf.ForEach {
 		if _itimediff(una, seg.sn) > 0 {
 			kcp.recycleSegment(seg)
 			count++
@@ -463,9 +460,7 @@ func (kcp *KCP) parse_una(una uint32) int {
 			break
 		}
 	}
-	if count > 0 {
-		kcp.snd_buf = kcp.remove_front(kcp.snd_buf, count)
-	}
+	kcp.snd_buf.Discard(count)
 	return count
 }
 
@@ -786,7 +781,7 @@ func (kcp *KCP) flush(ackOnly bool) uint32 {
 		newseg.conv = kcp.conv
 		newseg.cmd = IKCP_CMD_PUSH
 		newseg.sn = kcp.snd_nxt
-		kcp.snd_buf = append(kcp.snd_buf, newseg)
+		kcp.snd_buf.Push(newseg)
 		kcp.snd_nxt++
 		newSegsCount++
 	}
@@ -802,9 +797,7 @@ func (kcp *KCP) flush(ackOnly bool) uint32 {
 	var change, lostSegs, fastRetransSegs, earlyRetransSegs uint64
 	minrto := int32(kcp.interval)
 
-	ref := kcp.snd_buf[:len(kcp.snd_buf)] // for bounds check elimination
-	for k := range ref {
-		segment := &ref[k]
+	for segment := range kcp.snd_buf.ForEach {
 		needsend := false
 		if segment.acked == 1 {
 			continue
@@ -976,8 +969,7 @@ func (kcp *KCP) Check() uint32 {
 
 	tm_flush = _itimediff(ts_flush, current)
 
-	for k := range kcp.snd_buf {
-		seg := &kcp.snd_buf[k]
+	for seg := range kcp.snd_buf.ForEach {
 		diff := _itimediff(seg.resendts, current)
 		if diff <= 0 {
 			return current
@@ -1060,7 +1052,7 @@ func (kcp *KCP) WndSize(sndwnd, rcvwnd int) int {
 
 // WaitSnd gets how many packet is waiting to be sent
 func (kcp *KCP) WaitSnd() int {
-	return len(kcp.snd_buf) + kcp.snd_queue.Len()
+	return kcp.snd_buf.Len() + kcp.snd_queue.Len()
 }
 
 // remove front n elements from queue
@@ -1078,9 +1070,9 @@ func (kcp *KCP) remove_front(q []segment, n int) []segment {
 // Release all cached outgoing segments
 func (kcp *KCP) ReleaseTX() {
 	kcp.snd_queue.Clear()
-	for k := range kcp.snd_buf {
-		if kcp.snd_buf[k].data != nil {
-			xmitBuf.Put(kcp.snd_buf[k].data)
+	for seg := range kcp.snd_buf.ForEach {
+		if seg.data != nil {
+			xmitBuf.Put(seg.data)
 		}
 	}
 	kcp.snd_queue = nil

--- a/kcp_test.go
+++ b/kcp_test.go
@@ -141,10 +141,9 @@ func testlink(t *testing.T, client *lossyconn.LossyConn, server *lossyconn.Lossy
 
 func BenchmarkFlush(b *testing.B) {
 	kcp := NewKCP(1, func(buf []byte, size int) {})
-	kcp.snd_buf = make([]segment, 1024)
-	for k := range kcp.snd_buf {
-		kcp.snd_buf[k].xmit = 1
-		kcp.snd_buf[k].resendts = currentMs() + 10000
+	kcp.snd_buf = NewRingBuffer[segment](1024)
+	for range kcp.snd_buf.MaxLen() {
+		kcp.snd_buf.Push(segment{xmit: 1, resendts: currentMs() + 10000})
 	}
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -61,12 +61,27 @@ func (r *RingBuffer[T]) Pop() (T, bool) {
 
 // Peek returns the element at the head of the ring without removing it.
 // It returns the zero value and false if the ring is empty.
-func (r *RingBuffer[T]) Peek() (T, bool) {
-	var zero T
+func (r *RingBuffer[T]) Peek() (*T, bool) {
 	if r.Len() == 0 {
-		return zero, false
+		return nil, false
 	}
-	return r.elements[r.head], true
+	return &r.elements[r.head], true
+}
+
+// Discard discards the first N elements from the ring buffer.
+// Returns the number of elements that are actually discarded (<= n).
+func (r *RingBuffer[T]) Discard(n int) int {
+	n = min(n, r.Len())
+	if n == r.Len() {
+		r.Clear()
+		return n
+	}
+	var zero T
+	for range n {
+		r.elements[r.head] = zero
+		r.head = (r.head + 1) % len(r.elements)
+	}
+	return n
 }
 
 // ForEach iterates over each element in the ring buffer,

--- a/ringbuffer_test.go
+++ b/ringbuffer_test.go
@@ -134,6 +134,25 @@ func TestRingBuffer(t *testing.T) {
 	if r.Len() != 64 {
 		t.Errorf("Expected length 64 after pushing 32 more elements, got %d", r.Len())
 	}
+
+	// ringbuffer should be [32 ... 63, 0 ... 31]
+	evicted := 0
+	round := 0
+	expectedHead := []int{62, 28}
+	for !r.IsEmpty() {
+		evicted += r.Discard(30)
+		if round < len(expectedHead) {
+			if v, ok := r.Peek(); !ok || *v != expectedHead[round] {
+				t.Errorf("Invalid discard state: unexpected %d", *v)
+			}
+		} else if _, ok := r.Peek(); ok {
+			t.Errorf("Unexpected non-nil head element")
+		}
+		if r.Len()+evicted != 64 {
+			t.Errorf("Unexpected ringbuffer length after discard op")
+		}
+		round++
+	}
 }
 
 func TestRingBufferGrow(t *testing.T) {


### PR DESCRIPTION
这个改动将 rcv_buf 作为一个 ringbuffer 来进行维护，这样可以避免在处理乱序包/重传包时的频繁复制操作。

```
➜  src_workspace ./kcpbench.sh
HEAD is now at 18953de use ring on snd_queue
v5.6.21-28-g18953de
========================================= Original
2025/06/07 13:30:13 beginning tests, encryption:salsa20, fec:10/3
goos: linux
goarch: amd64
pkg: github.com/xtaci/kcp-go/v5
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkRecvBuf/recv_buf_ooo_1-32         	   29088	     40679 ns/op	  12586203 segments/sec	   12442 B/op	     512 allocs/op
BenchmarkRecvBuf/recv_buf_ooo_16-32        	   24807	     48936 ns/op	  10462619 segments/sec	   42202 B/op	     538 allocs/op
BenchmarkRecvBuf/recv_buf_ooo_64-32        	   20647	     58362 ns/op	   8772762 segments/sec	   45996 B/op	     518 allocs/op
BenchmarkRecvBuf/recv_buf_ooo_256-32       	   14031	     86161 ns/op	   5942383 segments/sec	   47529 B/op	     514 allocs/op
BenchmarkRecvBuf/recv_buf_ooo_512-32       	    9666	    117474 ns/op	   4358429 segments/sec	   44523 B/op	     513 allocs/op
PASS
ok  	github.com/xtaci/kcp-go/v5	8.330s
========================================= Patch
2025/06/07 13:30:22 beginning tests, encryption:salsa20, fec:10/3
goos: linux
goarch: amd64
pkg: github.com/xtaci/kcp-go/v5
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkRecvBuf/recv_buf_ooo_1-32         	   26653	     41229 ns/op	  12418350 segments/sec	   12449 B/op	     512 allocs/op
BenchmarkRecvBuf/recv_buf_ooo_16-32        	   28087	     42915 ns/op	  11930462 segments/sec	   12449 B/op	     512 allocs/op
BenchmarkRecvBuf/recv_buf_ooo_64-32        	   27126	     43847 ns/op	  11677106 segments/sec	   12446 B/op	     512 allocs/op
BenchmarkRecvBuf/recv_buf_ooo_256-32       	   26247	     45806 ns/op	  11177663 segments/sec	   12450 B/op	     512 allocs/op
BenchmarkRecvBuf/recv_buf_ooo_512-32       	   25472	     47303 ns/op	  10823814 segments/sec	   12451 B/op	     512 allocs/op
PASS
ok  	github.com/xtaci/kcp-go/v5	8.185s
HEAD is now at 18953de use ring on snd_queue
```

附件为 benchmark 以及 unit test，感觉没什么合并进去的必要，仅供参考。
[benchtest.zip](https://github.com/user-attachments/files/20640755/benchtest.zip)
