### PR TITLE
udpsession may drop correctly decoded packets

### DIFF
--- a/sess.go
+++ b/sess.go
@@ -825,11 +825,8 @@ func (s *UDPSession) kcpInput(data []byte) {
 			// If there're some packets recovered from FEC, feed them into kcp
 			for _, r := range recovers {
 				if len(r) >= 2 { // must be larger than 2bytes
-					sz := binary.LittleEndian.Uint16(r)
-					if int(sz) <= len(r) && sz >= 2 {
-						if ret := s.kcp.Input(r[2:sz], false, s.ackNoDelay); ret != 0 {
-							kcpInErrors++
-						}
+					if ret := s.kcp.Input(r[2:], false, s.ackNoDelay); ret != 0 {
+						kcpInErrors++
 					}
 				}
 				// recycle the buffer


### PR DESCRIPTION
Recently, I started using this KCP-based project, and while testing over localhost (where packets are decoded locally and re-sent to another endpoint), I occasionally observe that the number of decoded/recovered packets exceeds the number of packets actually received. In some cases, although the counts match, the contents of the recovered packets appear to be truncated. I'm only using the FEC component from KCP and not KCP itself, but it seems to me that the FEC decoder should be usable independently.

During unit testing, I noticed that the value obtained from:

sz := binary.LittleEndian.Uint16(r)
is often larger than the length of the recovered slice r itself.

for example:
recoverd: [132 0 10 0 49 95 85 120 107 65 88 79 111 122 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]

Here, sz = 132, which is clearly larger than the length of the packet.
The original test string is only 10 characters long: "1_UxkAXOoz" (I add a uint16 to specified it's length)

another example:
[102 0 7 0 49 95 79 107 114 68 112 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
for string "1_OkrDp"
 
If I add a defensive check like
if int(sz) <= len(r)
then such packets will be dropped. However, from what I can see, the packet contents appear to be fully and correctly recovered. If I don’t include this check, all of my test cases pass successfully, and I haven’t encountered any instances of incorrect recovery.

This leads me to believe that this part of the code logic might be problematic (or too strict), and I'm wondering whether the length calculation here should be revisited.