### PR TITLE
fix: wrapped udp connection

### DIFF
--- a/readloop_linux.go
+++ b/readloop_linux.go
@@ -89,7 +89,7 @@ func (s *UDPSession) readLoop() {
 // monitor is the optimized version of monitor for linux utilizing recvmmsg syscall
 func (l *Listener) monitor() {
 	var xconn batchConn
-	if _, ok := l.conn.(*net.UDPConn); ok {
+	if _, ok := l.conn.(udpConn); ok {
 		addr, err := net.ResolveUDPAddr("udp", l.conn.LocalAddr().String())
 		if err == nil {
 			if addr.IP.To4() != nil {


### PR DESCRIPTION
使用与官方相同的检查逻辑而非硬断言 `*net.UDPConn` 以允许被包装后的 UDPConn

https://github.com/golang/net/blob/v0.48.0/internal/socket/rawconn.go#L31

Patchset #311