### PR TITLE
refactor: use modern syntax for test & example

### DIFF
--- a/autotune_test.go
+++ b/autotune_test.go
@@ -32,8 +32,8 @@ func TestAutoTune(t *testing.T) {
 	signals := []uint32{0, 0, 0, 0, 0, 0}
 
 	tune := autoTune{}
-	for i := 0; i < len(signals); i++ {
-		if signals[i] == 0 {
+	for i, signal := range signals {
+		if signal == 0 {
 			tune.Sample(false, uint32(i))
 		} else {
 			tune.Sample(true, uint32(i))
@@ -45,8 +45,8 @@ func TestAutoTune(t *testing.T) {
 
 	signals = []uint32{1, 0, 1, 0, 0, 1}
 	tune = autoTune{}
-	for i := 0; i < len(signals); i++ {
-		if signals[i] == 0 {
+	for i, signal := range signals {
+		if signal == 0 {
 			tune.Sample(false, uint32(i))
 		} else {
 			tune.Sample(true, uint32(i))
@@ -57,8 +57,8 @@ func TestAutoTune(t *testing.T) {
 
 	signals = []uint32{1, 0, 0, 0, 0, 1}
 	tune = autoTune{}
-	for i := 0; i < len(signals); i++ {
-		if signals[i] == 0 {
+	for i, signal := range signals {
+		if signal == 0 {
 			tune.Sample(false, uint32(i))
 		} else {
 			tune.Sample(true, uint32(i))
@@ -69,7 +69,7 @@ func TestAutoTune(t *testing.T) {
 
 	// minimal test
 	tune = autoTune{}
-	for i := 0; i < 1024; i++ {
+	for i := range 1024 {
 		if i%maxAutoTuneSamples == 0 {
 			tune.Sample(false, uint32(i))
 		} else {

--- a/bufferpool_test.go
+++ b/bufferpool_test.go
@@ -10,11 +10,13 @@ func TestBufferPoolGetSize(t *testing.T) {
 	// Check length
 	if len(buf) != mtuLimit {
 		t.Fatalf("expected len=%d, got %d", mtuLimit, len(buf))
+		return
 	}
 
 	// Check capacity
 	if cap(buf) != mtuLimit {
 		t.Fatalf("expected cap=%d, got %d", mtuLimit, cap(buf))
+		return
 	}
 }
 
@@ -34,10 +36,12 @@ func TestBufferPoolPutAndReuse(t *testing.T) {
 	// Check if it is reused by comparing pointer address
 	if &buf2[0] != &buf[0] {
 		t.Fatalf("expected buffer reuse, but got a new one")
+		return
 	}
 
 	if buf2[0] != 99 {
 		t.Fatalf("expected reused buffer to keep previous data")
+		return
 	}
 }
 
@@ -54,5 +58,6 @@ func TestBufferPoolPutWrongSizeIgnored(t *testing.T) {
 
 	if cap(buf) != mtuLimit {
 		t.Fatalf("pool accepted wrong-sized buffer; expected cap=%d, got %d", mtuLimit, cap(buf))
+		return
 	}
 }

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -37,6 +37,7 @@ func TestSM4(t *testing.T) {
 	bc, err := NewSM4BlockCrypt(pass[:16])
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	cryptTest(t, bc)
 }
@@ -45,6 +46,7 @@ func TestAES(t *testing.T) {
 	bc, err := NewAESBlockCrypt(pass[:32])
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	cryptTest(t, bc)
 }
@@ -53,6 +55,7 @@ func TestTEA(t *testing.T) {
 	bc, err := NewTEABlockCrypt(pass[:16])
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	cryptTest(t, bc)
 }
@@ -61,6 +64,7 @@ func TestXOR(t *testing.T) {
 	bc, err := NewSimpleXORBlockCrypt(pass[:32])
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	cryptTest(t, bc)
 }
@@ -69,6 +73,7 @@ func TestBlowfish(t *testing.T) {
 	bc, err := NewBlowfishBlockCrypt(pass[:32])
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	cryptTest(t, bc)
 }
@@ -77,6 +82,7 @@ func TestNone(t *testing.T) {
 	bc, err := NewNoneBlockCrypt(pass[:32])
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	cryptTest(t, bc)
 }
@@ -85,6 +91,7 @@ func TestCast5(t *testing.T) {
 	bc, err := NewCast5BlockCrypt(pass[:16])
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	cryptTest(t, bc)
 }
@@ -93,6 +100,7 @@ func Test3DES(t *testing.T) {
 	bc, err := NewTripleDESBlockCrypt(pass[:24])
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	cryptTest(t, bc)
 }
@@ -101,6 +109,7 @@ func TestTwofish(t *testing.T) {
 	bc, err := NewTwofishBlockCrypt(pass[:32])
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	cryptTest(t, bc)
 }
@@ -109,6 +118,7 @@ func TestXTEA(t *testing.T) {
 	bc, err := NewXTEABlockCrypt(pass[:16])
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	cryptTest(t, bc)
 }
@@ -117,6 +127,7 @@ func TestSalsa20(t *testing.T) {
 	bc, err := NewSalsa20BlockCrypt(pass[:32])
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
 	cryptTest(t, bc)
 }
@@ -137,6 +148,7 @@ func BenchmarkSM4(b *testing.B) {
 	bc, err := NewSM4BlockCrypt(pass[:16])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 	benchCrypt(b, bc)
 }
@@ -145,6 +157,7 @@ func BenchmarkAES128(b *testing.B) {
 	bc, err := NewAESBlockCrypt(pass[:16])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 
 	benchCrypt(b, bc)
@@ -154,6 +167,7 @@ func BenchmarkAES192(b *testing.B) {
 	bc, err := NewAESBlockCrypt(pass[:24])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 
 	benchCrypt(b, bc)
@@ -163,6 +177,7 @@ func BenchmarkAES256(b *testing.B) {
 	bc, err := NewAESBlockCrypt(pass[:32])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 
 	benchCrypt(b, bc)
@@ -172,6 +187,7 @@ func BenchmarkTEA(b *testing.B) {
 	bc, err := NewTEABlockCrypt(pass[:16])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 	benchCrypt(b, bc)
 }
@@ -180,6 +196,7 @@ func BenchmarkXOR(b *testing.B) {
 	bc, err := NewSimpleXORBlockCrypt(pass[:32])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 	benchCrypt(b, bc)
 }
@@ -188,6 +205,7 @@ func BenchmarkBlowfish(b *testing.B) {
 	bc, err := NewBlowfishBlockCrypt(pass[:32])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 	benchCrypt(b, bc)
 }
@@ -196,6 +214,7 @@ func BenchmarkNone(b *testing.B) {
 	bc, err := NewNoneBlockCrypt(pass[:32])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 	benchCrypt(b, bc)
 }
@@ -204,6 +223,7 @@ func BenchmarkCast5(b *testing.B) {
 	bc, err := NewCast5BlockCrypt(pass[:16])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 	benchCrypt(b, bc)
 }
@@ -212,6 +232,7 @@ func Benchmark3DES(b *testing.B) {
 	bc, err := NewTripleDESBlockCrypt(pass[:24])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 	benchCrypt(b, bc)
 }
@@ -228,6 +249,7 @@ func BenchmarkXTEA(b *testing.B) {
 	bc, err := NewXTEABlockCrypt(pass[:16])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 	benchCrypt(b, bc)
 }
@@ -236,6 +258,7 @@ func BenchmarkSalsa20(b *testing.B) {
 	bc, err := NewSalsa20BlockCrypt(pass[:32])
 	if err != nil {
 		b.Fatal(err)
+		return
 	}
 	benchCrypt(b, bc)
 }
@@ -248,8 +271,8 @@ func benchCrypt(b *testing.B, bc BlockCrypt) {
 
 	b.ReportAllocs()
 	b.SetBytes(int64(len(enc) * 2))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	
+	for b.Loop() {
 		bc.Encrypt(enc, data)
 		bc.Decrypt(dec, enc)
 	}
@@ -258,7 +281,7 @@ func benchCrypt(b *testing.B, bc BlockCrypt) {
 func BenchmarkCRC32(b *testing.B) {
 	content := make([]byte, 1024)
 	b.SetBytes(int64(len(content)))
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		crc32.ChecksumIEEE(content)
 	}
 }

--- a/examples/echo.go
+++ b/examples/echo.go
@@ -13,18 +13,24 @@ import (
 func main() {
 	key := pbkdf2.Key([]byte("demo pass"), []byte("demo salt"), 1024, 32, sha1.New)
 	block, _ := kcp.NewAESBlockCrypt(key)
-	if listener, err := kcp.ListenWithOptions("127.0.0.1:12345", block, 10, 3); err == nil {
-		// spin-up the client
-		go client()
-		for {
-			s, err := listener.AcceptKCP()
-			if err != nil {
-				log.Fatal(err)
-			}
-			go handleEcho(s)
-		}
-	} else {
+
+	listener, err := kcp.ListenWithOptions("127.0.0.1:12345", block, 10, 3)
+	if err != nil {
 		log.Fatal(err)
+		return
+	}
+	defer listener.Close()
+
+	// spin-up the client
+	go client()
+	for {
+		s, err := listener.AcceptKCP()
+		if err != nil {
+			log.Fatal(err)
+			return
+		}
+
+		go handleEcho(s)
 	}
 }
 
@@ -38,7 +44,7 @@ func handleEcho(conn *kcp.UDPSession) {
 			return
 		}
 
-		n, err = conn.Write(buf[:n])
+		_, err = conn.Write(buf[:n])
 		if err != nil {
 			log.Println(err)
 			return
@@ -54,24 +60,32 @@ func client() {
 	time.Sleep(time.Second)
 
 	// dial to the echo server
-	if sess, err := kcp.DialWithOptions("127.0.0.1:12345", block, 10, 3); err == nil {
-		for {
-			data := time.Now().String()
-			buf := make([]byte, len(data))
-			log.Println("sent:", data)
-			if _, err := sess.Write([]byte(data)); err == nil {
-				// read back the data
-				if _, err := io.ReadFull(sess, buf); err == nil {
-					log.Println("recv:", string(buf))
-				} else {
-					log.Fatal(err)
-				}
-			} else {
-				log.Fatal(err)
-			}
-			time.Sleep(time.Second)
-		}
-	} else {
+	sess, err := kcp.DialWithOptions("127.0.0.1:12345", block, 10, 3)
+	if err != nil {
 		log.Fatal(err)
+		return
+	}
+	defer sess.Close()
+
+	for {
+		data := time.Now().String()
+		buf := make([]byte, len(data))
+		log.Println("sent:", data)
+
+		_, err := sess.Write([]byte(data))
+		if err != nil {
+			log.Fatal(err)
+			return
+		}
+
+		// read back the data
+		_, err = io.ReadFull(sess, buf)
+		if err != nil {
+			log.Fatal(err)
+			return
+		}
+
+		log.Println("recv:", string(buf))
+		time.Sleep(time.Second)
 	}
 }

--- a/fec_test.go
+++ b/fec_test.go
@@ -38,7 +38,7 @@ func TestFECEncodeConsecutive(t *testing.T) {
 	t.Logf("dataSize:%v, paritySize:%v", dataSize, paritySize)
 	group := 0
 	sent := 0
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if i%dataSize == 0 {
 			group++
 		}
@@ -58,10 +58,15 @@ func TestFECEncodeConsecutive(t *testing.T) {
 				expected := uint32((group-1)*(dataSize+paritySize) + dataSize + idx)
 				if seqid != expected {
 					t.Fatalf("expected parity shard:%v actual seqid %v", expected, seqid)
+					return
 				}
 			}
-		} else if sent%dataSize == 0 {
+			continue
+		}
+
+		if sent%dataSize == 0 {
 			t.Log("no parity:", len(ps))
+			continue
 		}
 	}
 }
@@ -79,7 +84,7 @@ func TestFECDecodeLoss(t *testing.T) {
 	recovered := 0
 	parityLost := 0
 
-	for group := 0; group < 100; group++ {
+	for group := range 100 {
 		losses := make(map[int]bool)
 
 		lost := 0
@@ -96,9 +101,10 @@ func TestFECDecodeLoss(t *testing.T) {
 
 		if len(losses) != parityShards {
 			t.Fatalf("Expected %v losses, got %v", parityShards, len(losses))
+			return
 		}
 
-		for i := 0; i < dataShards+parityShards; i++ {
+		for i := range dataShards + parityShards {
 			sent++
 			if losses[i] {
 				t.Logf("Lost packet %v in group %v", groupSize*group+i, group)
@@ -154,7 +160,7 @@ func BenchmarkFECEncode(b *testing.B) {
 	b.ReportAllocs()
 	b.SetBytes(payLoad)
 	encoder := newFECEncoder(dataSize, paritySize, 0)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		data := make([]byte, payLoad)
 		encoder.encode(data, 200)
 	}

--- a/ringbuffer_test.go
+++ b/ringbuffer_test.go
@@ -12,7 +12,7 @@ func TestRingSize(t *testing.T) {
 	}
 
 	// re-zero
-	for i := 0; i < 64; i++ {
+	for i := range 64 {
 		r.Push(i)
 		r.Pop()
 		if r.Len() != 0 {
@@ -51,15 +51,15 @@ func TestRingSize(t *testing.T) {
 func TestRingSize2(t *testing.T) {
 	// emulate a condition where head = 32， tail=31, and Len() = 63
 	r := NewRingBuffer[int](64)
-	for i := 0; i < 63; i++ {
+	for i := range 63 {
 		r.Push(i)
 	}
-	for i := 0; i < 32; i++ {
+	for range 32 {
 		if _, ok := r.Pop(); !ok {
 			t.Errorf("Expected to pop value, but got none")
 		}
 	}
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		r.Push(i + 63)
 		if r.Len() != i+(63-32+1) {
 			t.Errorf("Expected length %d after popping 31 elements, got %d", i+(63-32+1), r.Len())
@@ -104,14 +104,14 @@ func TestRingBuffer(t *testing.T) {
 		t.Errorf("Expected length 0, got %d", r.Len())
 	}
 
-	for i := 0; i < 64; i++ {
+	for i := range 64 {
 		r.Push(i)
 		if r.Len() != i+1 {
 			t.Errorf("Expected length %d, got %d", i+1, r.Len())
 		}
 	}
 
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		val, ok := r.Pop()
 		if !ok || val != i {
 			t.Errorf("Expected to pop %d, got %d (ok: %v)", i, val, ok)
@@ -124,7 +124,7 @@ func TestRingBuffer(t *testing.T) {
 
 	// Push more elements to test the ring's behavior
 	size := r.Len()
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		r.Push(i)
 		if r.Len() != i+1+size {
 			t.Errorf("Expected length %d, got %d", i+1+size, r.Len())
@@ -192,10 +192,11 @@ func TestRingBufferGrow(t *testing.T) {
 	}
 
 	// Check values are preserved in correct order
-	for i := 0; i < pushCount; i++ {
+	for i := range pushCount {
 		v, ok := r.Pop()
 		if !ok {
 			t.Fatalf("expected to pop value at index %d", i)
+			return
 		}
 		if v != i {
 			t.Errorf("expected value %d, got %d", i, v)
@@ -237,7 +238,7 @@ func TestRingForEach(t *testing.T) {
 
 func TestRingForEachReverse(t *testing.T) {
 	r := NewRingBuffer[int](10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		r.Push(i)
 	}
 


### PR DESCRIPTION
重构了测试和示例

- 移除不必要的 else 分支

- 添加 defer 回收资源

> 特别说明: panic 不含影响 defer 回收资源

- 为测试异常情况添加 return
- 使用新版本内置的 `b.Loop()` 来代替 `b.N`
- 使用 `for range`

Patchset #311