### PR TITLE
chores: use global entropy & add chacha8

### DIFF
--- a/crypt_test.go
+++ b/crypt_test.go
@@ -27,7 +27,6 @@ import (
 	"crypto/aes"
 	"crypto/md5"
 	"crypto/rand"
-	"crypto/sha1"
 	"hash/crc32"
 	"io"
 	"testing"
@@ -271,7 +270,7 @@ func benchCrypt(b *testing.B, bc BlockCrypt) {
 
 	b.ReportAllocs()
 	b.SetBytes(int64(len(enc) * 2))
-	
+
 	for b.Loop() {
 		bc.Encrypt(enc, data)
 		bc.Decrypt(dec, enc)
@@ -290,45 +289,27 @@ func BenchmarkCsprngSystem(b *testing.B) {
 	data := make([]byte, md5.Size)
 	b.SetBytes(int64(len(data)))
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		io.ReadFull(rand.Reader, data)
 	}
 }
 
-func BenchmarkCsprngMD5(b *testing.B) {
-	var data [md5.Size]byte
-	b.SetBytes(md5.Size)
-
-	for i := 0; i < b.N; i++ {
-		data = md5.Sum(data[:])
-	}
-}
-func BenchmarkCsprngSHA1(b *testing.B) {
-	var data [sha1.Size]byte
-	b.SetBytes(sha1.Size)
-
-	for i := 0; i < b.N; i++ {
-		data = sha1.Sum(data[:])
-	}
-}
-
-func BenchmarkCsprngNonceMD5(b *testing.B) {
-	var ng nonceMD5
-	ng.Init()
-	b.SetBytes(md5.Size)
-	data := make([]byte, md5.Size)
-	for i := 0; i < b.N; i++ {
-		ng.Fill(data)
-	}
-}
-
-func BenchmarkCsprngNonceAES128(b *testing.B) {
-	var ng nonceAES128
-	ng.Init()
-
+func BenchmarkCsprngAES128(b *testing.B) {
+	var data [aes.BlockSize]byte
 	b.SetBytes(aes.BlockSize)
-	data := make([]byte, aes.BlockSize)
-	for i := 0; i < b.N; i++ {
-		ng.Fill(data)
+
+	r := NewEntropyAES()
+	for b.Loop() {
+		io.ReadFull(r, data[:])
+	}
+}
+
+func BenchmarkCsprngChacha8(b *testing.B) {
+	var data [8]byte
+	b.SetBytes(8)
+
+	r := NewEntropyChacha8()
+	for b.Loop() {
+		io.ReadFull(r, data[:])
 	}
 }

--- a/entropy.go
+++ b/entropy.go
@@ -25,52 +25,137 @@ package kcp
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/md5"
-	"crypto/rand"
+	crand "crypto/rand"
 	"io"
+	"math/rand/v2"
+	"runtime"
+	"sync"
+
+	"golang.org/x/sys/cpu"
 )
 
-// Entropy defines a entropy source
-//
-//	Entropy in this file generate random bits for the first 16-bytes of each packets.
-type Entropy interface {
-	Init()
-	Fill(nonce []byte)
-}
+const reseedInterval = 1 << 24
 
-// nonceMD5 nonce generator for packet header
-type nonceMD5 struct {
-	seed [md5.Size]byte
-}
+var (
+	hasAESAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasSSE41 && cpu.X86.HasSSSE3
+	hasAESAsmARM64 = cpu.ARM64.HasAES
+	hasAESAsmS390X = cpu.S390X.HasAES
+	hasAESAsmPPC64 = runtime.GOARCH == "ppc64" || runtime.GOARCH == "ppc64le"
 
-func (n *nonceMD5) Init() { /*nothing required*/ }
+	hasAESHardwareSupport = hasAESAsmAMD64 || hasAESAsmARM64 || hasAESAsmS390X || hasAESAsmPPC64
 
-func (n *nonceMD5) Fill(nonce []byte) {
-	if n.seed[0] == 0 { // entropy update
-		io.ReadFull(rand.Reader, n.seed[:])
+	entropy io.Reader = NewEntropy()
+)
+
+func NewEntropy() io.Reader {
+	if hasAESHardwareSupport {
+		return NewEntropyAES()
 	}
-	n.seed = md5.Sum(n.seed[:])
-	copy(nonce, n.seed[:])
+
+	return NewEntropyChacha8()
 }
 
-// nonceAES128 nonce generator for packet headers
-type nonceAES128 struct {
-	seed  [aes.BlockSize]byte
+func SetEntropy(r io.Reader) {
+	entropy = r
+}
+
+func fillRand(p []byte) {
+	if len(p) <= 0 {
+		return
+	}
+	io.ReadFull(entropy, p)
+}
+
+type rngAES struct {
+	mutex sync.Mutex
 	block cipher.Block
+	seed  [16]byte
+	count uint64
 }
 
-func (n *nonceAES128) Init() {
-	var key [16]byte //aes-128
-	io.ReadFull(rand.Reader, key[:])
-	io.ReadFull(rand.Reader, n.seed[:])
-	block, _ := aes.NewCipher(key[:])
-	n.block = block
-}
+func NewEntropyAES() io.Reader {
+	r := new(rngAES)
 
-func (n *nonceAES128) Fill(nonce []byte) {
-	if n.seed[0] == 0 { // entropy update
-		io.ReadFull(rand.Reader, n.seed[:])
+	var key [16]byte
+	io.ReadFull(crand.Reader, key[:])
+	io.ReadFull(crand.Reader, r.seed[:])
+
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		panic(err)
 	}
-	n.block.Encrypt(n.seed[:], n.seed[:])
-	copy(nonce, n.seed[:])
+	r.block = block
+	return r
+}
+
+func (r *rngAES) reseed() {
+	if r.count < reseedInterval {
+		r.count++
+		return
+	}
+
+	var key [16]byte
+	io.ReadFull(crand.Reader, key[:])
+	io.ReadFull(crand.Reader, r.seed[:])
+
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		panic(err)
+	}
+	r.block = block
+	r.count = 0
+}
+
+func (r *rngAES) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.reseed()
+	r.block.Encrypt(r.seed[:], r.seed[:])
+	return copy(p, r.seed[:]), nil
+}
+
+type rngChacha8 struct {
+	mutex sync.Mutex
+	rand  *rand.ChaCha8
+	count uint64
+}
+
+func NewEntropyChacha8() io.Reader {
+	var seed [32]byte
+	io.ReadFull(crand.Reader, seed[:])
+
+	return &rngChacha8{
+		rand: rand.NewChaCha8(seed),
+	}
+}
+
+func (r *rngChacha8) reseed() {
+	if r.count < reseedInterval {
+		r.count++
+		return
+	}
+
+	var seed [32]byte
+	io.ReadFull(crand.Reader, seed[:])
+
+	r.rand.Seed(seed)
+	r.count = 0
+}
+
+func (r *rngChacha8) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.reseed()
+	n, err := r.rand.Read(p)
+	return n, err
 }


### PR DESCRIPTION
- 修改为使用全局熵源并允许替换 (也许会有人想用 `crypto/rand`)
- 添加 Chacha8 算法并在不支持 AES 时作为默认来源
- 使用 io.Reader 接口和 io.ReadFull 以确保 Nonce 可以完整填充