### PR TITLE
feat: support AEAD

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -65,6 +65,30 @@ type BlockCrypt interface {
 	Decrypt(dst, src []byte)
 }
 
+var _ BlockCrypt = &aeadCrypt{}
+
+type aeadCrypt struct {
+	cipher.AEAD
+}
+
+func (aeadCrypt) Encrypt(_, _ []byte) {
+	panic("called Encrypt on AEAD crypt")
+}
+
+func (aeadCrypt) Decrypt(_, _ []byte) {
+	panic("called Decrypt on AEAD crypt")
+}
+
+func NewAEADCrypt(aead cipher.AEAD) BlockCrypt {
+	if aead == nil {
+		return nil
+	}
+
+	return &aeadCrypt{aead}
+}
+
+var _ BlockCrypt = &blockCrypt{}
+
 type blockCrypt struct {
 	enc, dec       sync.Mutex
 	encbuf, decbuf []byte // 64bit alignment enc/dec buffer


### PR DESCRIPTION
- 允许传入 cipher.AEAD 作为加密方式

---

CFB 加密格式


encrypt( [Nonce] [CRC32] [FEC] [KCP])

AEAD 加密格式

[Nonce] encrypt([FEC] [KCP]) [AEAD Tag]

---

要点如下:

Header 长度变更 (仅 Nonce), 尾部留空 (已经有了)

> 如果把 CRC32 看作 AEAD Tag 的话, CRC在前, AEAD 在后

MTU 计算变更 Header + (AEAD Overhead)
