### PR TITLE
Add unreliable datagram support to UDPSession

### DIFF
--- a/fec.go
+++ b/fec.go
@@ -54,6 +54,16 @@ const (
 	typeData           = 0xf1
 	typeParity         = 0xf2
 	maxShardSets       = 3
+
+	// typeDatagram indicates a unreliable datagram packet.
+	//
+	// This value follows the FEC extension space and is intentionally chosen
+	// to avoid any overlap with KCP command [81-84] and fragment fields [0-255].
+	// Datagram packets are NOT protected by FEC and are delivered unreliably.
+	typeDatagram = 0xf3
+
+	// Total header size for a datagram packet: conv (4B) + type (2B)
+	datagramHeaderSize = 6
 )
 
 // fecPacket is a decoded FEC packet


### PR DESCRIPTION
This PR adds support for unreliable datagram packets to UDPSession.

The design is inspired by QUIC DATAGRAMs (RFC 9221), providing a lightweight,
message-oriented transport that coexists with the reliable KCP byte stream.

Highlights:
- Datagram packets are sent unreliably and are never retransmitted.
- Datagram packets are not protected by FEC.
- Datagram packets reuse the existing encryption and transmit pipeline.
- A per-session datagram handler can be registered to receive incoming datagrams.
- If no handler is registered, datagram packets are transparently handled by
  the existing KCP logic.

Important notes:
- The datagram handler is invoked synchronously from the KCP input path.
  It must return quickly and must not perform blocking operations.
- The datagram type value is carefully chosen to avoid any overlap with
  existing KCP command or fragment fields.

This change is fully backward-compatible and does not affect existing KCP
stream behavior.