### PR TITLE
Lower SetMtu minimum from 50 to IKCP_OVERHEAD+1 (25)

### DIFF
--- a/kcp.go
+++ b/kcp.go
@@ -1078,7 +1078,7 @@ func (kcp *KCP) Check() uint32 {
 
 // SetMtu changes MTU size, default is 1400
 func (kcp *KCP) SetMtu(mtu int) int {
-	if mtu < 50 || mtu < IKCP_OVERHEAD {
+	if mtu < IKCP_OVERHEAD+1 {
 		return -1
 	}
 

--- a/kcp.go
+++ b/kcp.go
@@ -1078,7 +1078,7 @@ func (kcp *KCP) Check() uint32 {
 
 // SetMtu changes MTU size, default is 1400
 func (kcp *KCP) SetMtu(mtu int) int {
-	if mtu < IKCP_OVERHEAD+1 {
+	if mtu <= IKCP_OVERHEAD {
 		return -1
 	}
 

--- a/sess_test.go
+++ b/sess_test.go
@@ -1112,10 +1112,14 @@ func TestSetMTU(t *testing.T) {
 	}
 	defer cli.Close()
 
-	ok := cli.SetMtu(49)
-	if ok {
-		t.Fatal("can not set mtu small than 50")
-		return
+	if cli.SetMtu(IKCP_OVERHEAD) {
+		t.Fatal("should not allow MTU equal to IKCP_OVERHEAD")
+	}
+	if cli.SetMtu(IKCP_OVERHEAD - 1) {
+		t.Fatal("should not allow MTU below IKCP_OVERHEAD")
+	}
+	if !cli.SetMtu(IKCP_OVERHEAD + cryptHeaderSize + fecHeaderSizePlus2 + 1) {
+		t.Fatal("should allow MTU just above total overhead")
 	}
 
 	cli.SetMtu(1500)


### PR DESCRIPTION
The hardcoded minimum MTU of 50 bytes is an arbitrary value with no basis in the protocol — the actual minimum is `IKCP_OVERHEAD` (24-byte KCP header) plus 1 byte of payload.
This change lowers the limit to 25, allowing smaller MTUs in constrained transport scenarios without breaking any protocol guarantees.