### PR TITLE
fix(listener): dedup AcceptKCP for handshake retransmit from same client (#340)

### DIFF
--- a/dedup_test.go
+++ b/dedup_test.go
@@ -1,0 +1,100 @@
+package kcp
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakePacketConn struct {
+	addr net.Addr
+}
+
+func (f *fakePacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	select {}
+}
+
+func (f *fakePacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	return len(p), nil
+}
+
+func (f *fakePacketConn) Close() error                       { return nil }
+func (f *fakePacketConn) LocalAddr() net.Addr                { return f.addr }
+func (f *fakePacketConn) SetDeadline(t time.Time) error      { return nil }
+func (f *fakePacketConn) SetReadDeadline(t time.Time) error  { return nil }
+func (f *fakePacketConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func buildKCPPushPacket(conv uint32) []byte {
+	buf := make([]byte, IKCP_OVERHEAD)
+	buf[0] = byte(conv)
+	buf[1] = byte(conv >> 8)
+	buf[2] = byte(conv >> 16)
+	buf[3] = byte(conv >> 24)
+	buf[4] = IKCP_CMD_PUSH
+	buf[5] = 0
+	buf[6] = 32
+	buf[7] = 0
+	return buf
+}
+
+// TestListenerDedupSameAddr is a regression test for xtaci/kcp-go#340:
+// when multiple packets from the same remote address race the Listener's
+// session-tracking map, AcceptKCP can hand out duplicate UDPSession objects
+// for the same RemoteAddr. We expect exactly one session per (addr, conv).
+func TestListenerDedupSameAddr(t *testing.T) {
+	l := new(Listener)
+	l.conn = &fakePacketConn{addr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}}
+	l.ownConn = false
+	l.sessions = make(map[string]*UDPSession)
+	l.chAccepts = make(chan *UDPSession, acceptBacklog)
+	l.chSocketReadError = make(chan struct{})
+	l.die = make(chan struct{})
+
+	remote := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 50000}
+	const conv = uint32(0xCAFEBABE)
+	pkt := buildKCPPushPacket(conv)
+
+	const N = 32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			data := make([]byte, len(pkt))
+			copy(data, pkt)
+			l.packetInput(data, remote)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	accepted := 0
+	drain := true
+	for drain {
+		select {
+		case s := <-l.chAccepts:
+			accepted++
+			if s.RemoteAddr().String() != remote.String() {
+				t.Errorf("accepted session has wrong RemoteAddr=%s, want %s",
+					s.RemoteAddr(), remote)
+			}
+		default:
+			drain = false
+		}
+	}
+	if accepted != 1 {
+		t.Fatalf("Listener handed out %d sessions for a single (addr, conv); want 1 (issue #340)", accepted)
+	}
+
+	l.sessionLock.RLock()
+	mapSize := len(l.sessions)
+	_, ok := l.sessions[remote.String()]
+	l.sessionLock.RUnlock()
+	if mapSize != 1 || !ok {
+		t.Fatalf("Listener.sessions has %d entries (expected 1) and contains %q=%v",
+			mapSize, remote.String(), ok)
+	}
+}

--- a/sess.go
+++ b/sess.go
@@ -1263,12 +1263,29 @@ func (l *Listener) packetInput(data []byte, addr net.Addr) {
 		return
 	}
 
+	// Take the write lock first and re-check under it. Without this, two
+	// packets from the same remote address (e.g. a handshake retransmit or
+	// duplicate packet) can both miss on the RLock lookup above and each
+	// spawn a UDPSession, leading to AcceptKCP returning two sessions for
+	// the same RemoteAddr (issue #340).
+	l.sessionLock.Lock()
+	if existing, ok := l.sessions[addr.String()]; ok {
+		l.sessionLock.Unlock()
+		// A concurrent packet from the same remote already created the
+		// session; if its conv matches, feed this packet into it instead of
+		// spawning a duplicate. If the conv differs, drop this packet — the
+		// stale-conv reset path above will handle reconnection.
+		if conv == existing.kcp.conv {
+			existing.kcpInput(data)
+		}
+		return
+	}
+
 	// new session
 	s = newUDPSession(conv, l.dataShards, l.parityShards, l, l.conn, false, addr, l.block)
-	s.kcpInput(data)
-	l.sessionLock.Lock()
 	l.sessions[addr.String()] = s
 	l.sessionLock.Unlock()
+	s.kcpInput(data)
 	l.chAccepts <- s
 }
 


### PR DESCRIPTION
Draft for direction — bug is fresh (filed today) and not maintainer-validated yet, so I'd love your read before going further.

## Problem

`Listener.packetInput` (in `sess.go`) looks up `l.sessions[addr.String()]` under an `RLock`, and if the entry is missing it falls through to create a new `UDPSession` and writes it into the map under a separate `Lock`. There is a TOCTOU window between the two locks: two packets from the same remote address (e.g. a handshake retransmit, a duplicate from `recvmmsg`, or any case where the application invokes `packetInput` from more than one goroutine) can both miss on the read lock, each construct a `UDPSession`, and each `l.chAccepts <- s`. The second write into `l.sessions[addr]` silently overwrites the first.

Net effect, matching the symptom in #340:
- `AcceptKCP()` returns two `*UDPSession` for the same `RemoteAddr`.
- The session held in `l.sessions[addr]` is whichever one wrote last, so `closeSession(remote)` removes the map binding regardless of which `UDPSession` the caller closes — and from the caller's perspective that "closes" the other session too (no more packets get routed to it).

## Repro

`dedup_test.go` (added in this PR) drives `Listener.packetInput` directly with a fake `net.PacketConn` and fires 32 copies of the same PUSH packet from the same remote address, then drains `chAccepts`. On `master` I see 2–3 sessions handed out; the assert wants exactly 1.

```
$ go test -race -run TestListenerDedupSameAddr -count=5 -v
# master:
    dedup_test.go:89: Listener handed out 2 sessions for a single (addr, conv); want 1 (issue #340)
    dedup_test.go:89: Listener handed out 3 sessions for a single (addr, conv); want 1 (issue #340)
    ...
# with this patch:
--- PASS: TestListenerDedupSameAddr (0.00s)  (x5)
```

## Candidate fix

Take `sessionLock.Lock()` *before* allocating the new session and re-check the map under the write lock. If a concurrent goroutine already inserted a session for this remote, feed the incoming packet into it (when `conv` matches) and skip the duplicate.

Diff is ~20 lines in `sess.go`. Insertion order is also tightened so the session is in `l.sessions` before `chAccepts <- s` — that way any later packet for the same remote that races the accept handler can still find it.

## Open questions

1. Is the dedup key right? I keyed on `addr.String()` (same key already used by the map). Should the dedup also consider `conv`, or is the existing stale-conv reset path above (`s.Close()` when `conv != s.kcp.conv && sn == 0`) intended to be the canonical reconnect mechanism?
2. The duplicate-packet branch silently drops the packet when the conv mismatches and `sn != 0`. That matches the existing behavior in the "session already exists" branch above, but I want to make sure I'm not papering over a different bug.
3. I considered using `sync.Map` or a per-addr lock map but didn't want to widen the patch surface. Happy to follow whichever direction you prefer.

Reproducer is small and standalone; happy to iterate on style, structure, or rewrite the whole fix in a different direction if I read this wrong.
