### PR TITLE
feat: add ResetRTO API for immediate recovery

### DIFF
--- a/kcp.go
+++ b/kcp.go
@@ -1145,3 +1145,17 @@ func (kcp *KCP) SetLogger(mask KCPLogType, logger logoutput_callback) {
 	kcp.logmask = mask
 	kcp.log = logger
 }
+
+// ResetRTO resets the retransmission timeout (RTO) and resend timestamp
+// for all segments currently in the send buffer.
+//
+// This forces all unacknowledged segments to be eligible for immediate
+// retransmission during the next flush.
+func (kcp *KCP) ResetRTO() {
+	current := currentMs()
+
+	for segment := range kcp.snd_buf.ForEach {
+		segment.rto = kcp.rx_rto
+		segment.resendts = current
+	}
+}

--- a/sess.go
+++ b/sess.go
@@ -1120,6 +1120,21 @@ func (s *UDPSession) kcpInput(data []byte) {
 	}
 }
 
+// ResetRTO resets the retransmission timers for all pending segments.
+//
+// This method does not trigger a synchronous flush. Retransmission will
+// naturally occur at the next background update tick, governed by the
+// `interval` configured via SetNoDelay (default 100ms).
+//
+// It is intended for cases where the application knows connectivity
+// has been restored and wants to resume data delivery without waiting
+// for existing retransmission timers to expire.
+func (s *UDPSession) ResetRTO() {
+	s.mu.Lock()
+	s.kcp.ResetRTO()
+	s.mu.Unlock()
+}
+
 // -----------------------------------------------------------------------
 // Listener: server-side session multiplexer
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes  #343.

Introduces `ResetRTO()` to help applications quickly resume data delivery once they detect that network connectivity has been restored.

This is highly beneficial in mobile or volatile network environments. When the application detects link restoration (e.g., cellular to Wi-Fi handover) via out-of-band signals, it can use this API to resume data delivery immediately without waiting for long penalizing RTO timers to expire.